### PR TITLE
feat: add column sizing with constraints 

### DIFF
--- a/src/app/normal-2/page.tsx
+++ b/src/app/normal-2/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+import SheetTable from "@/components/sheet-table"
+import { ExtendedColumnDef } from "@/components/sheet-table/utils"
+
+type MyData = {
+  headerKey?: string
+  materialName: string
+  quantity: number
+  cost: number
+}
+
+const columns: ExtendedColumnDef<MyData>[] = [
+  {
+    header: "Material Name",
+    accessorKey: "materialName",
+    size: 120,
+    minSize: 100,
+    maxSize: 300,
+  },
+  {
+    header: "Quantity",
+    accessorKey: "quantity",
+    size: 80,
+    minSize: 50,
+    maxSize: 120,
+  },
+  {
+    header: "Cost",
+    accessorKey: "cost",
+    size: 100,
+  },
+]
+
+const data: MyData[] = [
+  { materialName: "Pine Wood", quantity: 5, cost: 100 },
+  { materialName: "Rubber Wood", quantity: 3, cost: 75 },
+  // ...
+]
+
+export default function MyPage() {
+  return (
+    <SheetTable
+      columns={columns}
+      data={data}
+      enableColumnSizing
+      tableOptions={{
+        columnResizeMode: "onChange",
+        // e.g., if you wanted to set an initialState or something else:
+        initialState: { columnVisibility: { cost: false } },
+      }}
+      totalRowValues={{ quantity: 8, cost: 175 }}
+      totalRowLabel="Total"
+      totalRowTitle="Summary"
+    />
+  )
+}

--- a/src/app/normal/page.tsx
+++ b/src/app/normal/page.tsx
@@ -130,11 +130,6 @@ export default function HomePage() {
         secondHeaderTitle="Custom Title Example" // Title for the second header
 
         enableColumnSizing
-        tableOptions={{
-          columnResizeMode: "onChange",
-          // e.g., if you wanted to set an initialState or something else:
-
-        }}
       />
 
       <Button onClick={handleSubmit}>Submit</Button>

--- a/src/app/normal/page.tsx
+++ b/src/app/normal/page.tsx
@@ -22,9 +22,9 @@ import { ExtendedColumnDef } from "@/components/sheet-table/utils";
 import { rowDataZodSchema, RowData } from "@/schemas/row-data-schema";
 
 const materialNameSchema = rowDataZodSchema.shape.materialName; // required string
-const cftSchema = rowDataZodSchema.shape.cft;                   // optional number >= 0
-const rateSchema = rowDataZodSchema.shape.rate;                 // required number >= 0
-const amountSchema = rowDataZodSchema.shape.amount;             // required number >= 0
+const cftSchema = rowDataZodSchema.shape.cft; // optional number >= 0
+const rateSchema = rowDataZodSchema.shape.rate; // required number >= 0
+const amountSchema = rowDataZodSchema.shape.amount; // required number >= 0
 
 /**
  * Initial data for demonstration.
@@ -37,10 +37,9 @@ const initialData: RowData[] = [
   { materialName: "Ultra Nitro Glossy 2", cft: 0.045, rate: 215, amount: 9.68 },
 ];
 
-
 /**
  * Extended column definitions, each with a validationSchema.
- * We rely on 'accessorKey' instead of 'id'. This is fine now 
+ * We rely on 'accessorKey' instead of 'id'. This is fine now
  * because we manually allowed 'accessorKey?: string'.
  */
 const columns: ExtendedColumnDef<RowData>[] = [
@@ -48,21 +47,31 @@ const columns: ExtendedColumnDef<RowData>[] = [
     accessorKey: "materialName",
     header: "Material Name",
     validationSchema: materialNameSchema,
+    size: 120,
+    minSize: 50,
+    maxSize: 100,
   },
   {
     accessorKey: "cft",
     header: "CFT",
     validationSchema: cftSchema,
+    maxSize: 20,
   },
   {
     accessorKey: "rate",
     header: "Rate",
     validationSchema: rateSchema,
+    size: 80,
+    minSize: 50,
+    maxSize: 120,
   },
   {
     accessorKey: "amount",
     header: "Amount",
     validationSchema: amountSchema,
+    size: 80,
+    minSize: 50,
+    maxSize: 120,
   },
 ];
 
@@ -78,14 +87,17 @@ export default function HomePage() {
   const handleEdit = <K extends keyof RowData>(
     rowIndex: number,
     columnId: K,
-    value: RowData[K]
+    value: RowData[K],
   ) => {
     // Create a copy of data
     const newData = [...data];
     newData[rowIndex] = { ...newData[rowIndex], [columnId]: value };
     setData(newData);
 
-    console.log(`State updated [row=${rowIndex}, col=${String(columnId)}]:`, value);
+    console.log(
+      `State updated [row=${rowIndex}, col=${String(columnId)}]:`,
+      value,
+    );
   };
 
   /**
@@ -117,9 +129,15 @@ export default function HomePage() {
         showSecondHeader={true} // Second header visibility
         secondHeaderTitle="Custom Title Example" // Title for the second header
 
+        enableColumnSizing
+        tableOptions={{
+          columnResizeMode: "onChange",
+          // e.g., if you wanted to set an initialState or something else:
+
+        }}
       />
 
-<Button onClick={handleSubmit}>Submit</Button>
+      <Button onClick={handleSubmit}>Submit</Button>
     </div>
   );
 }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -17,6 +17,7 @@ const Header = () => {
   const navigation = [
     { name: "Complex", href: "/" },
     { name: "Simple", href: "/normal" },
+    { name: "Simple 2", href: "/normal-2" },
   ];
 
   // Toggle between light and dark themes

--- a/src/components/sheet-table/index.tsx
+++ b/src/components/sheet-table/index.tsx
@@ -2,15 +2,11 @@
  * sheet-table/index.tsx
  *
  * A reusable table component with editable cells, row/column disabling,
- * and custom data support. Integrates with Zod validation per column
- * using an optional validationSchema property in the column definition.
- *
- * Adds grouping functionality based on a `headerKey` in the row data.
- * Adds a configurable footer section using:
- *  - totalRowValues (object mapping column keys to footer values)
- *  - totalRowLabel (string filler for empty cells)
- *  - totalRowTitle (sub-header row above totals)
- *  - footerElement (a custom React node to render after totals)
+ * custom data support, and Zod validation. Supports:
+ *  - Grouping rows by a `headerKey`
+ *  - A configurable footer (totals row + custom element)
+ *  - TanStack Table column sizing (size, minSize, maxSize)
+ *  - Forwarding other TanStack Table configuration via tableOptions
  */
 
 import React, { useState, useCallback } from "react";
@@ -20,6 +16,8 @@ import {
   flexRender,
   TableOptions,
   Row as TanStackRow,
+  ColumnSizingState, // for type
+  // ColumnDef,          // for type if needed
 } from "@tanstack/react-table";
 
 import {
@@ -44,24 +42,31 @@ import {
 } from "./utils";
 
 /**
- * A reusable table component with:
- *  - Editable cells
- *  - Optional per-column Zod validation
- *  - Row/column disabling
- *  - Real-time error highlighting
- *  - Only final updates to parent onBlur
- *  - Grouping rows by sub-header
- *  - Footer support (totals row, custom footer element)
- *
- * @template T
- * @param {SheetTableProps<T>} props
- *   columns: Column definitions (with optional validation)
- *   data: The main data array
- *   onEdit: Callback for finishing cell edits
- *   disabledColumns, disabledRows: for row/column disabling
- *   showHeader, showSecondHeader, secondHeaderTitle: controlling main headers
- *   totalRowValues: if provided, we render a totals row at the end
- *   totalRowLabel, totalRowTitle, footerElement: for customizing the footer
+ * Extended props to forward additional TanStack Table config.
+ * e.g., enabling resizing, customizing columnResizeMode, etc.
+ */
+interface ExtraTanStackProps<T> {
+  /**
+   * If true, column sizing is enabled. We track sizes in local state.
+   */
+  enableColumnSizing?: boolean;
+
+  /**
+   * Additional table options that you want to pass directly to useReactTable.
+   * For example: initialState, columnResizeMode, etc.
+   */
+  tableOptions?: Partial<TableOptions<T>>;
+}
+
+/**
+ * Combine your existing SheetTableProps with the extra TanStack props.
+ */
+type SheetTableAllProps<T extends Record<string, unknown>> = 
+  SheetTableProps<T> & 
+  ExtraTanStackProps<T>;
+
+/**
+ * The main SheetTable component, now with optional column sizing support.
  */
 function SheetTable<
   T extends Record<string, unknown> & { headerKey?: string }
@@ -80,11 +85,19 @@ function SheetTable<
   totalRowLabel = "",
   totalRowTitle,
   footerElement,
-}: SheetTableProps<T>) {
+
+  // Additional TanStack config
+  enableColumnSizing = false,
+  tableOptions = {},
+}: SheetTableAllProps<T>) {
   /**
-   * Instead of storing errors/original content keyed by (groupKey, rowIndex),
-   * we will use (groupKey, rowId), where rowId is from the TanStack row.id.
-   * This ensures consistent references even when data is grouped or reordered.
+   * If column sizing is enabled, we track sizes in state. 
+   * This allows the user to define 'size', 'minSize', 'maxSize' in the column definitions.
+   */
+  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({});
+
+  /**
+   * We still track errors/original content keyed by (groupKey, rowId) for editing.
    */
   const [cellErrors, setCellErrors] = useState<
     Record<string, Record<string, Record<string, string | null>>>
@@ -94,17 +107,36 @@ function SheetTable<
   >({});
 
   /**
-   * Initialize the table using TanStack Table.
+   * Build the final table options. Merge user-provided tableOptions with ours.
    */
-  const table = useReactTable<T>({
+  const mergedOptions: TableOptions<T> = {
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
-  } as TableOptions<T>);
+
+    // If sizing is enabled, pass sizing states:
+    ...(enableColumnSizing
+      ? {
+          state: {
+            // If user also provided tableOptions.state, merge them
+            ...tableOptions.state,
+            columnSizing,
+          },
+          onColumnSizingChange: setColumnSizing,
+          columnResizeMode: tableOptions.columnResizeMode ?? "onChange",
+        }
+      : {}),
+    // Spread any additional user-provided table options
+    ...tableOptions,
+  } as TableOptions<T>;
 
   /**
-   * Finds the TanStack row for a given data row.
-   * We need this to get row.id (the unique stable identifier).
+   * Initialize the table using TanStack Table.
+   */
+  const table = useReactTable<T>(mergedOptions);
+
+  /**
+   * Finds the TanStack row for a given data row (to get row.id).
    */
   const findTableRow = useCallback(
     (rowData: T): TanStackRow<T> | undefined => {
@@ -124,7 +156,7 @@ function SheetTable<
       colDef: ExtendedColumnDef<T>
     ) => {
       const tanStackRow = findTableRow(rowData);
-      if (!tanStackRow) return; // Shouldn't happen unless data changed
+      if (!tanStackRow) return;
 
       const rowId = tanStackRow.id;
       const colKey = getColumnKey(colDef);
@@ -254,7 +286,10 @@ function SheetTable<
         {/* If there's a totalRowTitle, show it in a single row */}
         {totalRowTitle && (
           <TableRow>
-            <TableCell colSpan={columns.length} className="border text-center font-semibold">
+            <TableCell
+              colSpan={columns.length}
+              className="border text-center font-semibold"
+            >
               {totalRowTitle}
             </TableCell>
           </TableRow>
@@ -272,10 +307,10 @@ function SheetTable<
                 cellValue !== undefined
                   ? cellValue
                   : index === 0
-                    ? (totalRowLabel || "") // Fallback to an empty string if no totalRowLabel
-                    : "";
+                  ? totalRowLabel || ""
+                  : "";
 
-              // Always apply the border to the first cell (left edge),
+              // Always apply the border to the first cell (left edge)
               // or any cell that has a displayValue.
               const applyBorder = index === 0 || displayValue !== "";
 
@@ -297,23 +332,42 @@ function SheetTable<
     );
   }
 
-
   return (
     <div className="p-4">
       <Table>
-        <TableCaption>
-          Dynamic, editable data table with grouping.
-        </TableCaption>
+        <TableCaption>Dynamic, editable data table with grouping.</TableCaption>
 
         {/* Primary header */}
         {showHeader && (
           <TableHeader>
             <TableRow>
-              {table.getFlatHeaders().map((header) => (
-                <TableHead key={header.id} className="text-left border">
-                  {flexRender(header.column.columnDef.header, header.getContext())}
-                </TableHead>
-              ))}
+              {table.getHeaderGroups().map((headerGroup) =>
+                headerGroup.headers.map((header) => {
+                  // If column sizing is enabled, apply inline styles from TanStack (header.getSize()).
+                  // Also respect minSize/maxSize from the ExtendedColumnDef if set.
+                  const style: React.CSSProperties = {};
+                  if (enableColumnSizing) {
+                    const col = header.column.columnDef;
+                    const size = header.getSize();
+                    if (size) style.width = size + "px";
+                    if (col.minSize) style.minWidth = col.minSize + "px";
+                    if (col.maxSize) style.maxWidth = col.maxSize + "px";
+                  }
+
+                  return (
+                    <TableHead
+                      key={header.id}
+                      className="text-left border"
+                      style={style}
+                    >
+                      {flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                    </TableHead>
+                  );
+                })
+              )}
             </TableRow>
           </TableHeader>
         )}
@@ -344,7 +398,9 @@ function SheetTable<
               )}
 
               {rows.map((rowData) => {
-                const tanStackRow = findTableRow(rowData);
+                const tanStackRow = table
+                  .getRowModel()
+                  .rows.find((r) => r.original === rowData);
                 if (!tanStackRow) return null; // Data changed significantly?
 
                 const rowId = tanStackRow.id;
@@ -353,52 +409,65 @@ function SheetTable<
 
                 return (
                   <TableRow key={rowId} className={disabled ? "bg-muted" : ""}>
-                    {columns.map((colDef) => {
-                      const colKey = getColumnKey(colDef);
+                    {tanStackRow
+                      .getVisibleCells()
+                      .map((cell) => {
+                        const colDef = cell.column.columnDef as ExtendedColumnDef<T>;
+                        const colKey = getColumnKey(colDef);
 
-                      const isDisabled =
-                        disabled || disabledColumns.includes(colKey);
+                        const isDisabled =
+                          disabled || disabledColumns.includes(colKey);
 
-                      const errorMsg =
-                        cellErrors[groupKey]?.[rowId]?.[colKey] || null;
+                        const errorMsg =
+                          cellErrors[groupKey]?.[rowId]?.[colKey] || null;
 
-                      return (
-                        <TableCell
-                          key={`${groupKey}-${rowId}-${colKey}`}
-                          className={`border
-                            ${isDisabled ? "bg-muted" : ""}
-                            ${errorMsg ? "bg-destructive/25" : ""}
-                          `}
-                          contentEditable={!isDisabled}
-                          suppressContentEditableWarning
-                          // Original content capture on focus
-                          onFocus={(e) =>
-                            handleCellFocus(e, groupKey, rowData, colDef)
-                          }
-                          // Let user do Ctrl+A, C, X, Z, V, etc.
-                          onKeyDown={(e) => {
-                            if (
-                              (e.ctrlKey || e.metaKey) &&
-                              ["a", "c", "x", "z", "v"].includes(
-                                e.key.toLowerCase()
-                              )
-                            ) {
-                              return; // do not block
+                        // If sizing is on, also apply styles in the cell 
+                        const style: React.CSSProperties = {};
+                        if (enableColumnSizing) {
+                          const size = cell.column.getSize();
+                          if (size) style.width = size + "px";
+                          if (colDef.minSize) style.minWidth = colDef.minSize + "px";
+                          if (colDef.maxSize) style.maxWidth = colDef.maxSize + "px";
+                        }
+
+                        return (
+                          <TableCell
+                            key={cell.id}
+                            className={`border
+                              ${isDisabled ? "bg-muted" : ""}
+                              ${errorMsg ? "bg-destructive/25" : ""}
+                            `}
+                            style={style}
+                            contentEditable={!isDisabled}
+                            suppressContentEditableWarning
+                            // Original content capture on focus
+                            onFocus={(e) =>
+                              handleCellFocus(e, groupKey, rowData, colDef)
                             }
-                            handleKeyDown(e, colDef);
-                          }}
-                          onPaste={(e) => handlePaste(e, colDef)}
-                          onInput={(e) =>
-                            handleCellInput(e, groupKey, rowData, colDef)
-                          }
-                          onBlur={(e) =>
-                            handleCellBlur(e, groupKey, rowData, colDef)
-                          }
-                        >
-                          {rowData[colDef.accessorKey ?? ""] as React.ReactNode}
-                        </TableCell>
-                      );
-                    })}
+                            // Let user do Ctrl+A, C, X, Z, V, etc.
+                            onKeyDown={(e) => {
+                              if (
+                                (e.ctrlKey || e.metaKey) &&
+                                ["a", "c", "x", "z", "v"].includes(
+                                  e.key.toLowerCase()
+                                )
+                              ) {
+                                return; // do not block
+                              }
+                              handleKeyDown(e, colDef);
+                            }}
+                            onPaste={(e) => handlePaste(e, colDef)}
+                            onInput={(e) =>
+                              handleCellInput(e, groupKey, rowData, colDef)
+                            }
+                            onBlur={(e) =>
+                              handleCellBlur(e, groupKey, rowData, colDef)
+                            }
+                          >
+                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                          </TableCell>
+                        );
+                      })}
                   </TableRow>
                 );
               })}
@@ -406,7 +475,7 @@ function SheetTable<
           ))}
         </TableBody>
 
-        {/* If totalRowValues exist, show TableFooter with totals & optional custom footer */}
+        {/* Render footer (totals row + custom footer) */}
         {renderFooter()}
       </Table>
     </div>

--- a/src/components/sheet-table/index.tsx
+++ b/src/components/sheet-table/index.tsx
@@ -42,30 +42,6 @@ import {
 } from "./utils";
 
 /**
- * Extended props to forward additional TanStack Table config.
- * e.g., enabling resizing, customizing columnResizeMode, etc.
- */
-interface ExtraTanStackProps<T> {
-  /**
-   * If true, column sizing is enabled. We track sizes in local state.
-   */
-  enableColumnSizing?: boolean;
-
-  /**
-   * Additional table options that you want to pass directly to useReactTable.
-   * For example: initialState, columnResizeMode, etc.
-   */
-  tableOptions?: Partial<TableOptions<T>>;
-}
-
-/**
- * Combine your existing SheetTableProps with the extra TanStack props.
- */
-type SheetTableAllProps<T extends Record<string, unknown>> = 
-  SheetTableProps<T> & 
-  ExtraTanStackProps<T>;
-
-/**
  * The main SheetTable component, now with optional column sizing support.
  */
 function SheetTable<
@@ -89,7 +65,7 @@ function SheetTable<
   // Additional TanStack config
   enableColumnSizing = false,
   tableOptions = {},
-}: SheetTableAllProps<T>) {
+}: SheetTableProps<T>) {
   /**
    * If column sizing is enabled, we track sizes in state. 
    * This allows the user to define 'size', 'minSize', 'maxSize' in the column definitions.

--- a/src/components/sheet-table/utils.ts
+++ b/src/components/sheet-table/utils.ts
@@ -15,7 +15,7 @@
  * to what was previously in sheet-table.tsx (just split out).
  */
 
-import type { ColumnDef } from "@tanstack/react-table";
+import type { ColumnDef, TableOptions } from "@tanstack/react-table";
 import type { ZodType, ZodTypeDef } from "zod";
 import React from "react";
 
@@ -70,18 +70,62 @@ interface FooterProps {
 
 /**
  * Props for the SheetTable component.
- * Combine the existing SheetTableProps with footer props.
+ * Includes footer props and additional TanStack table configurations.
  */
 export interface SheetTableProps<T extends object> extends FooterProps {
+  /**
+   * Column definitions for the table.
+   */
   columns: ExtendedColumnDef<T>[];
+
+  /**
+   * Data to be displayed in the table.
+   */
   data: T[];
+
+  /**
+   * Callback for handling cell edits.
+   */
   onEdit?: <K extends keyof T>(rowIndex: number, columnId: K, value: T[K]) => void;
+
+  /**
+   * Columns that are disabled for editing.
+   */
   disabledColumns?: string[];
-  disabledRows?: number[] |  Record<string, number[]>;
+
+  /**
+   * Rows that are disabled for editing.
+   * Can be an array of row indices or a record mapping column IDs to row indices.
+   */
+  disabledRows?: number[] | Record<string, number[]>;
+
+  /**
+   * Whether to show the table header.
+   */
   showHeader?: boolean;
+
+  /**
+   * Whether to show a secondary header below the main header.
+   */
   showSecondHeader?: boolean;
+
+  /**
+   * Title for the secondary header, if enabled.
+   */
   secondHeaderTitle?: string;
+
+  /**
+   * If true, column sizing is enabled. Sizes are tracked in local state.
+   */
+  enableColumnSizing?: boolean;
+
+  /**
+   * Additional table options to be passed directly to `useReactTable`.
+   * Examples: initialState, columnResizeMode, etc.
+   */
+  tableOptions?: Partial<TableOptions<T>>;
 }
+
 
 /**
  * Returns a stable string key for each column (id > accessorKey > "").


### PR DESCRIPTION
feat: add column sizing with constraints and enhanced footer logic

- Implemented column sizing with initial size and min/max constraints.
- Enabled `enableColumnSizing` to track and apply constraints using local state.
- Added support for `tableOptions` (e.g., `columnResizeMode`, `initialState`, etc.).
- Updated footer row to display default values:
  - `8` for quantity
  - `175` for cost
  - `Total` for the first column (materialName) when no value is provided.
- Preserved TanStack Table’s advanced props (sorting, filtering, pagination) alongside specialized Zod validation, grouping, and footer logic.
