### PR TITLE
feat(sheet-table): add support for dynamic and static className in Ex…

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,7 +43,7 @@ const initialData: RowData[] = [
     materialName: "NC Thinner (Spl)",
     cft: 0.202,
     rate: 93,
-    amount: 19.73,
+    amount: 101.73,
   },
   {
     headerKey: "Spraying",
@@ -64,7 +64,7 @@ const initialData: RowData[] = [
     materialName: "Ultra Nitro Glossy 2",
     cft: 0.045,
     rate: 215,
-    amount: 9.68,
+    amount: 120,
   },
 ];
 
@@ -78,6 +78,7 @@ const columns: ExtendedColumnDef<RowData>[] = [
     accessorKey: "materialName",
     header: "Material Name",
     validationSchema: materialNameSchema,
+    className: "text-center font-bold bg-yellow-100", // Static class name
   },
   {
     accessorKey: "cft",
@@ -93,6 +94,7 @@ const columns: ExtendedColumnDef<RowData>[] = [
     accessorKey: "amount",
     header: "Amount",
     validationSchema: amountSchema,
+    className: (row) => (row.amount > 100 ?  "text-green-500" : "text-red-500"), // Dynamic styling based on row data
   },
 ];
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -78,7 +78,7 @@ const columns: ExtendedColumnDef<RowData>[] = [
     accessorKey: "materialName",
     header: "Material Name",
     validationSchema: materialNameSchema,
-    className: "text-center font-bold bg-yellow-100", // Static class name
+    className: "text-center font-bold bg-yellow-100 dark:bg-yellow-800 dark:text-yellow-100", // Static styling
   },
   {
     accessorKey: "cft",

--- a/src/components/sheet-table/index.tsx
+++ b/src/components/sheet-table/index.tsx
@@ -20,6 +20,7 @@ import {
   // ColumnDef,          // for type if needed
 } from "@tanstack/react-table";
 
+// ** import ui components
 import {
   Table,
   TableBody,
@@ -31,6 +32,7 @@ import {
   TableFooter,
 } from "@/components/ui/table";
 
+// ** import utils
 import {
   ExtendedColumnDef,
   SheetTableProps,
@@ -40,6 +42,9 @@ import {
   handlePaste,
   isRowDisabled,
 } from "./utils";
+
+// ** import lib
+import { cn } from "@/lib/utils";
 
 /**
  * The main SheetTable component, now with optional column sizing support.
@@ -409,11 +414,17 @@ function SheetTable<
                         return (
                           <TableCell
                             key={cell.id}
-                            className={`border
-                              ${isDisabled ? "bg-muted" : ""}
-                              ${errorMsg ? "bg-destructive/25" : ""}
-                            `}
-                            style={style}
+                            className={cn(
+                              "border", // Base class
+                              {
+                                "bg-muted": isDisabled, // Apply bg-muted if the cell is disabled
+                                "bg-destructive/25": errorMsg, // Apply bg-destructive/25 if there's an error
+                              },
+                              typeof colDef.className === "function"
+                              ? colDef.className(rowData) // Dynamic class name based on row data
+                              : colDef.className // Static class name
+                            )}
+                            style={{ ...colDef.style, ...style }} // Combine column style with dynamic styles
                             contentEditable={!isDisabled}
                             suppressContentEditableWarning
                             // Original content capture on focus

--- a/src/components/sheet-table/utils.ts
+++ b/src/components/sheet-table/utils.ts
@@ -24,6 +24,7 @@ import React from "react";
  * - Inherits everything from TanStack's ColumnDef<TData, TValue>
  * - Forces existence of optional `accessorKey?: string` and `id?: string`
  * - Adds our optional `validationSchema` property (for column-level Zod).
+ * - Adds optional `className` and `style` properties for custom styling.
  */
 export type ExtendedColumnDef<
   TData extends object,
@@ -32,6 +33,8 @@ export type ExtendedColumnDef<
   id?: string;
   accessorKey?: string;
   validationSchema?: ZodType<any, ZodTypeDef, any>;
+  className?: string | ((row: TData) => string); // Allows static or dynamic class names
+  style?: React.CSSProperties; // style for inline styles
 };
 
 


### PR DESCRIPTION
…tendedColumnDef

- Updated `ExtendedColumnDef` to allow `className` as a string or a function `(row: TData) => string` for dynamic styling.
- Enhanced the cell rendering logic to resolve `className` dynamically using the provided function or apply it statically.
- Incorporated `clsx` for cleaner class name management in `TableCell` rendering.
- Ensured type safety and flexibility for both static and dynamic class names.