### PR TITLE
feat(row-data): add support for nested subRows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+
+logs.txt

--- a/src/app/normal-2/page.tsx
+++ b/src/app/normal-2/page.tsx
@@ -4,6 +4,7 @@ import { ExtendedColumnDef } from "@/components/sheet-table/utils"
 
 type MyData = {
   headerKey?: string
+  id: string
   materialName: string
   quantity: number
   cost: number
@@ -32,8 +33,8 @@ const columns: ExtendedColumnDef<MyData>[] = [
 ]
 
 const data: MyData[] = [
-  { materialName: "Pine Wood", quantity: 5, cost: 100 },
-  { materialName: "Rubber Wood", quantity: 3, cost: 75 },
+  { id: "1", materialName: "Pine Wood", quantity: 5, cost: 100 },
+  { id: "2", materialName: "Rubber Wood", quantity: 3, cost: 75 },
   // ...
 ]
 

--- a/src/app/normal/page.tsx
+++ b/src/app/normal/page.tsx
@@ -30,11 +30,11 @@ const amountSchema = rowDataZodSchema.shape.amount; // required number >= 0
  * Initial data for demonstration.
  */
 const initialData: RowData[] = [
-  { materialName: "Ultra Nitro Sealer", cft: 0.03, rate: 164, amount: 5.17 },
-  { materialName: "NC Thinner (Spl)", cft: 0.202, rate: 93, amount: 19.73 },
-  { materialName: "Ultra Nitro Sealer 2", cft: 0.072, rate: 164, amount: 12.4 },
-  { materialName: "Ultra Nitro Matt 2", cft: 0.051, rate: 209, amount: 11.19 },
-  { materialName: "Ultra Nitro Glossy 2", cft: 0.045, rate: 215, amount: 9.68 },
+  { id: "1", materialName: "Ultra Nitro Sealer", cft: 0.03, rate: 164, amount: 5.17 },
+  { id: "2", materialName: "NC Thinner (Spl)", cft: 0.202, rate: 93, amount: 19.73 },
+  { id: "3", materialName: "Ultra Nitro Sealer 2", cft: 0.072, rate: 164, amount: 12.4 },
+  { id: "4", materialName: "Ultra Nitro Matt 2", cft: 0.051, rate: 209, amount: 11.19 },
+  { id: "5", materialName: "Ultra Nitro Glossy 2", cft: 0.045, rate: 215, amount: 9.68 },
 ];
 
 /**
@@ -81,24 +81,28 @@ const columns: ExtendedColumnDef<RowData>[] = [
 export default function HomePage() {
   const [data, setData] = useState<RowData[]>(initialData);
 
-  /**
-   * onEdit callback: updates local state if the new value is valid.
-   */
-  const handleEdit = <K extends keyof RowData>(
-    rowIndex: number,
-    columnId: K,
-    value: RowData[K],
-  ) => {
-    // Create a copy of data
-    const newData = [...data];
-    newData[rowIndex] = { ...newData[rowIndex], [columnId]: value };
-    setData(newData);
-
-    console.log(
-      `State updated [row=${rowIndex}, col=${String(columnId)}]:`,
-      value,
-    );
-  };
+  
+    /**
+     * onEdit callback: updates local state if the new value is valid. (Normal usage)
+     */
+    const handleEdit = <K extends keyof RowData>(
+      rowId: string, // Unique identifier for the row
+      columnId: K,   // Column key
+      value: RowData[K], // New value for the cell
+    ) => {
+      setData((prevData) =>
+        prevData.map((row) =>
+          String(row.id) === rowId
+            ? { ...row, [columnId]: value } // Update the row if the ID matches
+            : row // Otherwise, return the row unchanged
+        )
+      );
+  
+      console.log(
+        `State updated [row id=${rowId}, column=${columnId}, value=${value}]`,
+        value,
+      );
+    };
 
   /**
    * Validate entire table on submit.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,23 +36,7 @@ const initialData: RowData[] = [
     materialName: "Ultra Nitro Sealer",
     cft: 0.03,
     rate: 164,
-    amount: 5.17,
-    subRows: [
-      {
-        headerKey: "Dipping - 2 times",
-        materialName: "Ultra Nitro Matt",
-        cft: 0.03,
-        rate: 209,
-        amount: 6.27,
-      },
-      {
-        headerKey: "Dipping - 2 times",
-        materialName: "Ultra Nitro Glossy",
-        cft: 0.03,
-        rate: 215,
-        amount: 6.45,
-      }
-    ]
+    amount: 5.17
   },
   {
     headerKey: "Dipping - 2 times",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,6 +33,7 @@ const amountSchema = rowDataZodSchema.shape.amount; // required number >= 0
 const initialData: RowData[] = [
   {
     headerKey: "Dipping - 2 times",
+    id: "1",
     materialName: "Ultra Nitro Sealer",
     cft: 0.03,
     rate: 164,
@@ -40,6 +41,7 @@ const initialData: RowData[] = [
   },
   {
     headerKey: "Dipping - 2 times",
+    id: "2",
     materialName: "NC Thinner (Spl)",
     cft: 0.202,
     rate: 93,
@@ -47,6 +49,7 @@ const initialData: RowData[] = [
   },
   {
     headerKey: "Spraying",
+    id: "3",
     materialName: "Ultra Nitro Sealer 2",
     cft: 0.072,
     rate: 164,
@@ -54,6 +57,7 @@ const initialData: RowData[] = [
   },
   {
     headerKey: "Spraying",
+    id: "4",
     materialName: "Ultra Nitro Matt 2",
     cft: 0.051,
     rate: 209,
@@ -61,11 +65,12 @@ const initialData: RowData[] = [
   },
   {
     headerKey: "Spraying",
+    id: "5",
     materialName: "Ultra Nitro Glossy 2",
     cft: 0.045,
     rate: 215,
     amount: 120,
-    
+
   },
 ];
 
@@ -95,7 +100,7 @@ const columns: ExtendedColumnDef<RowData>[] = [
     accessorKey: "amount",
     header: "Amount",
     validationSchema: amountSchema,
-    className: (row) => (row.amount > 100 ?  "text-green-500" : "text-red-500"), // Dynamic styling based on row data
+    className: (row) => (row.amount > 100 ? "text-green-500" : "text-red-500"), // Dynamic styling based on row data
   },
 ];
 
@@ -105,21 +110,25 @@ const columns: ExtendedColumnDef<RowData>[] = [
 export default function HomePage() {
   const [data, setData] = useState<RowData[]>(initialData);
 
+
   /**
-   * onEdit callback: updates local state if the new value is valid.
+   * onEdit callback: updates local state if the new value is valid. (Normal usage)
    */
   const handleEdit = <K extends keyof RowData>(
-    rowIndex: number,
-    columnId: K,
-    value: RowData[K],
+    rowId: string, // Unique identifier for the row
+    columnId: K,   // Column key
+    value: RowData[K], // New value for the cell
   ) => {
-    // Create a copy of data
-    const newData = [...data];
-    newData[rowIndex] = { ...newData[rowIndex], [columnId]: value };
-    setData(newData);
+    setData((prevData) =>
+      prevData.map((row) =>
+        String(row.id) === rowId
+          ? { ...row, [columnId]: value } // Update the row if the ID matches
+          : row // Otherwise, return the row unchanged
+      )
+    );
 
     console.log(
-      `State updated [row=${rowIndex}, col=${String(columnId)}]:`,
+      `State updated [row id=${rowId}, column=${columnId}, value=${value}]`,
       value,
     );
   };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,6 +37,22 @@ const initialData: RowData[] = [
     cft: 0.03,
     rate: 164,
     amount: 5.17,
+    subRows: [
+      {
+        headerKey: "Dipping - 2 times",
+        materialName: "Ultra Nitro Matt",
+        cft: 0.03,
+        rate: 209,
+        amount: 6.27,
+      },
+      {
+        headerKey: "Dipping - 2 times",
+        materialName: "Ultra Nitro Glossy",
+        cft: 0.03,
+        rate: 215,
+        amount: 6.45,
+      }
+    ]
   },
   {
     headerKey: "Dipping - 2 times",
@@ -65,6 +81,7 @@ const initialData: RowData[] = [
     cft: 0.045,
     rate: 215,
     amount: 120,
+    
   },
 ];
 

--- a/src/app/sub-rows/page.tsx
+++ b/src/app/sub-rows/page.tsx
@@ -1,20 +1,11 @@
-/**
- * normal/page.tsx
- *
- * Demonstration of using the extended SheetTable with Zod-based validation.
- */
-
 "use client";
 
 import React, { useState } from "react";
 
-// ** import 3rd party lib
-import { z } from "zod";
-
 // ** import ui components
 import { Button } from "@/components/ui/button";
 
-// ** import components
+// ** import component
 import SheetTable from "@/components/sheet-table";
 import { ExtendedColumnDef } from "@/components/sheet-table/utils";
 
@@ -22,63 +13,102 @@ import { ExtendedColumnDef } from "@/components/sheet-table/utils";
 import { rowDataZodSchema, RowData } from "@/schemas/row-data-schema";
 
 const materialNameSchema = rowDataZodSchema.shape.materialName; // required string
-const cftSchema = rowDataZodSchema.shape.cft; // optional number >= 0
-const rateSchema = rowDataZodSchema.shape.rate; // required number >= 0
-const amountSchema = rowDataZodSchema.shape.amount; // required number >= 0
+const cftSchema = rowDataZodSchema.shape.cft;                   // optional number >= 0
+const rateSchema = rowDataZodSchema.shape.rate;                 // required number >= 0
+const amountSchema = rowDataZodSchema.shape.amount;             // required number >= 0
 
 /**
  * Initial data for demonstration.
+ * All `id` values must be *unique strings* across all nested subRows.
  */
 const initialData: RowData[] = [
-  { materialName: "Ultra Nitro Sealer", cft: 0.03, rate: 164, amount: 5.17 },
   {
+    id: "1",
+    materialName: "Ultra Nitro Sealer",
+    cft: 0.03,
+    rate: 164,
+    amount: 5.17,
+  },
+  {
+    id: "2",
     materialName: "NC Thinner (Spl)",
     cft: 0.202,
     rate: 93,
     amount: 19.73,
     subRows: [
       {
+        id: "2.1",
         materialName: "NC Thinner (Spl) 1",
-        cft: 0.202,
-        rate: 93,
-        amount: 19.73,
+        cft: 0.203,
+        rate: 94,
+        amount: 20.0,
       },
       {
+        id: "2.2",
         materialName: "NC Thinner (Spl) 2",
-        cft: 0.202,
-        rate: 93,
-        amount: 19.73,
+        cft: 0.204,
+        rate: 95,
+        amount: 20.3,
       },
     ],
   },
-  { materialName: "Ultra Nitro Sealer 2", cft: 0.072, rate: 164, amount: 12.4 },
   {
+    id: "3",
+    materialName: "Ultra Nitro Sealer 2",
+    cft: 0.072,
+    rate: 165,
+    amount: 12.4,
+  },
+  {
+    id: "4",
     materialName: "Ultra Nitro Matt 2",
     cft: 0.051,
     rate: 209,
     amount: 11.19,
     subRows: [
       {
+        id: "4.1",
         materialName: "Ultra Nitro Matt 2 1",
-        cft: 0.051,
-        rate: 209,
-        amount: 11.19,
+        cft: 0.052,
+        rate: 210,
+        amount: 11.2,
+        subRows: [
+          {
+            id: "4.1.1",
+            materialName: "Ultra Nitro Matt 2 1 1",
+            cft: 0.053,
+            rate: 211,
+            amount: 11.3,
+          },
+          {
+            id: "4.1.2",
+            materialName: "Ultra Nitro Matt 2 1 2",
+            cft: 0.054,
+            rate: 212,
+            amount: 11.4,
+          },
+        ],
       },
       {
+        id: "4.2",
         materialName: "Ultra Nitro Matt 2 2",
-        cft: 0.051,
-        rate: 209,
-        amount: 11.19,
+        cft: 0.055,
+        rate: 213,
+        amount: 11.5,
       },
     ],
   },
-  { materialName: "Ultra Nitro Glossy 2", cft: 0.045, rate: 215, amount: 9.68 },
+  {
+    id: "5",
+    materialName: "Ultra Nitro Glossy 2",
+    cft: 0.045,
+    rate: 215,
+    amount: 9.68,
+  },
 ];
 
 /**
  * Extended column definitions, each with a validationSchema.
- * We rely on 'accessorKey' instead of 'id'. This is fine now
- * because we manually allowed 'accessorKey?: string'.
  */
 const columns: ExtendedColumnDef<RowData>[] = [
   {
@@ -114,6 +144,38 @@ const columns: ExtendedColumnDef<RowData>[] = [
 ];
 
 /**
+ * Recursively update a row in nested data by matching rowId with strict equality.
+ * Logs when it finds a match, so we can see exactly what's updated.
+ */
+function updateNestedRow<K extends keyof RowData>(
+  rows: RowData[],
+  rowId: string,
+  colKey: K,
+  newValue: RowData[K],
+): RowData[] {
+  return rows.map((row) => {
+    // If this row's ID matches rowId exactly, update it
+    if (row.id === rowId) {
+      console.log("updateNestedRow -> Found exact match:", rowId);
+      return { ...row, [colKey]: newValue };
+    }
+
+    // Otherwise, if the row has subRows, recurse
+    if (row.subRows && row.subRows.length > 0) {
+      // We only log if we are actually diving into them
+      console.log("updateNestedRow -> Checking subRows for row:", row.id);
+      return {
+        ...row,
+        subRows: updateNestedRow(row.subRows, rowId, colKey, newValue),
+      };
+    }
+
+    // If no match and no subRows, return row unchanged
+    return row;
+  });
+}
+
+/**
  * HomePage - shows how to integrate the SheetTable with per-column Zod validation.
  */
 export default function HomePage() {
@@ -123,33 +185,44 @@ export default function HomePage() {
    * onEdit callback: updates local state if the new value is valid.
    */
   const handleEdit = <K extends keyof RowData>(
-    rowIndex: number,
-    columnId: K,
-    value: RowData[K],
+    rowId: string, // Unique identifier for the row
+    columnId: K,   // Column key
+    value: RowData[K], // New value for the cell
   ) => {
-    // Create a copy of data
-    const newData = [...data];
-    newData[rowIndex] = { ...newData[rowIndex], [columnId]: value };
-    setData(newData);
-
-    console.log(
-      `State updated [row=${rowIndex}, col=${String(columnId)}]:`,
-      value,
-    );
+    setData((prevData) => {
+      const newRows = updateNestedRow(prevData, rowId, columnId, value);
+      // optional logging
+      console.log(
+        `State updated [row id=${rowId}, column=${columnId}, value=${value}]`
+      );
+      return newRows;
+    });
   };
 
   /**
-   * Validate entire table on submit.
-   * If any row fails, we log the errors. Otherwise, we log the data.
+   * Validate entire table (including subRows) on submit.
    */
   const handleSubmit = () => {
-    const arraySchema = z.array(rowDataZodSchema);
-    const result = arraySchema.safeParse(data);
+    const validateRows = (rows: RowData[]): boolean => {
+      for (const row of rows) {
+        // Validate this row
+        const result = rowDataZodSchema.safeParse(row);
+        if (!result.success) {
+          console.error("Row validation failed:", result.error.issues, row);
+          return false;
+        }
+        // Recursively validate subRows if present
+        if (row.subRows && row.subRows.length > 0) {
+          if (!validateRows(row.subRows)) return false;
+        }
+      }
+      return true;
+    };
 
-    if (!result.success) {
-      console.error("Table data is invalid:", result.error.issues);
-    } else {
+    if (validateRows(data)) {
       console.log("Table data is valid! Submitting:", data);
+    } else {
+      console.error("Table data is invalid. Check the logged errors.");
     }
   };
 
@@ -161,11 +234,12 @@ export default function HomePage() {
         columns={columns}
         data={data}
         onEdit={handleEdit}
-        disabledColumns={["materialName"]} // e.g. ["materialName"]
+        // e.g. disable editing materialName column
+        disabledColumns={["materialName"]}
         disabledRows={[2]}
-        showHeader={true} // First header visibility
-        showSecondHeader={true} // Second header visibility
-        secondHeaderTitle="Custom Title Example" // Title for the second header
+        showHeader={true}
+        showSecondHeader={true}
+        secondHeaderTitle="Custom Title Example"
         enableColumnSizing
       />
 

--- a/src/app/sub-rows/page.tsx
+++ b/src/app/sub-rows/page.tsx
@@ -1,0 +1,138 @@
+/**
+ * normal/page.tsx
+ *
+ * Demonstration of using the extended SheetTable with Zod-based validation.
+ */
+
+"use client";
+
+import React, { useState } from "react";
+
+// ** import 3rd party lib
+import { z } from "zod";
+
+// ** import ui components
+import { Button } from "@/components/ui/button";
+
+// ** import components
+import SheetTable from "@/components/sheet-table";
+import { ExtendedColumnDef } from "@/components/sheet-table/utils";
+
+// ** import zod schema for row data
+import { rowDataZodSchema, RowData } from "@/schemas/row-data-schema";
+
+const materialNameSchema = rowDataZodSchema.shape.materialName; // required string
+const cftSchema = rowDataZodSchema.shape.cft; // optional number >= 0
+const rateSchema = rowDataZodSchema.shape.rate; // required number >= 0
+const amountSchema = rowDataZodSchema.shape.amount; // required number >= 0
+
+/**
+ * Initial data for demonstration.
+ */
+const initialData: RowData[] = [
+  { materialName: "Ultra Nitro Sealer", cft: 0.03, rate: 164, amount: 5.17 },
+  { materialName: "NC Thinner (Spl)", cft: 0.202, rate: 93, amount: 19.73 },
+  { materialName: "Ultra Nitro Sealer 2", cft: 0.072, rate: 164, amount: 12.4 },
+  { materialName: "Ultra Nitro Matt 2", cft: 0.051, rate: 209, amount: 11.19 },
+  { materialName: "Ultra Nitro Glossy 2", cft: 0.045, rate: 215, amount: 9.68 },
+];
+
+/**
+ * Extended column definitions, each with a validationSchema.
+ * We rely on 'accessorKey' instead of 'id'. This is fine now
+ * because we manually allowed 'accessorKey?: string'.
+ */
+const columns: ExtendedColumnDef<RowData>[] = [
+  {
+    accessorKey: "materialName",
+    header: "Material Name",
+    validationSchema: materialNameSchema,
+    size: 120,
+    minSize: 50,
+    maxSize: 100,
+  },
+  {
+    accessorKey: "cft",
+    header: "CFT",
+    validationSchema: cftSchema,
+    maxSize: 20,
+  },
+  {
+    accessorKey: "rate",
+    header: "Rate",
+    validationSchema: rateSchema,
+    size: 80,
+    minSize: 50,
+    maxSize: 120,
+  },
+  {
+    accessorKey: "amount",
+    header: "Amount",
+    validationSchema: amountSchema,
+    size: 80,
+    minSize: 50,
+    maxSize: 120,
+  },
+];
+
+/**
+ * HomePage - shows how to integrate the SheetTable with per-column Zod validation.
+ */
+export default function HomePage() {
+  const [data, setData] = useState<RowData[]>(initialData);
+
+  /**
+   * onEdit callback: updates local state if the new value is valid.
+   */
+  const handleEdit = <K extends keyof RowData>(
+    rowIndex: number,
+    columnId: K,
+    value: RowData[K],
+  ) => {
+    // Create a copy of data
+    const newData = [...data];
+    newData[rowIndex] = { ...newData[rowIndex], [columnId]: value };
+    setData(newData);
+
+    console.log(
+      `State updated [row=${rowIndex}, col=${String(columnId)}]:`,
+      value,
+    );
+  };
+
+  /**
+   * Validate entire table on submit.
+   * If any row fails, we log the errors. Otherwise, we log the data.
+   */
+  const handleSubmit = () => {
+    const arraySchema = z.array(rowDataZodSchema);
+    const result = arraySchema.safeParse(data);
+
+    if (!result.success) {
+      console.error("Table data is invalid:", result.error.issues);
+    } else {
+      console.log("Table data is valid! Submitting:", data);
+    }
+  };
+
+  return (
+    <div style={{ padding: "1rem" }}>
+      <h1 style={{ marginBottom: "1rem" }}>Home Page with Zod Validation</h1>
+
+      <SheetTable<RowData>
+        columns={columns}
+        data={data}
+        onEdit={handleEdit}
+        disabledColumns={["materialName"]} // e.g. ["materialName"]
+        disabledRows={[2]}
+        showHeader={true} // First header visibility
+        showSecondHeader={true} // Second header visibility
+        secondHeaderTitle="Custom Title Example" // Title for the second header
+
+        enableColumnSizing
+      />
+
+      <Button onClick={handleSubmit}>Submit</Button>
+    </div>
+  );
+}

--- a/src/app/sub-rows/page.tsx
+++ b/src/app/sub-rows/page.tsx
@@ -234,9 +234,6 @@ export default function HomePage() {
         columns={columns}
         data={data}
         onEdit={handleEdit}
-        // e.g. disable editing materialName column
-        disabledColumns={["materialName"]}
-        disabledRows={[2]}
         showHeader={true}
         showSecondHeader={true}
         secondHeaderTitle="Custom Title Example"

--- a/src/app/sub-rows/page.tsx
+++ b/src/app/sub-rows/page.tsx
@@ -31,9 +31,47 @@ const amountSchema = rowDataZodSchema.shape.amount; // required number >= 0
  */
 const initialData: RowData[] = [
   { materialName: "Ultra Nitro Sealer", cft: 0.03, rate: 164, amount: 5.17 },
-  { materialName: "NC Thinner (Spl)", cft: 0.202, rate: 93, amount: 19.73 },
+  {
+    materialName: "NC Thinner (Spl)",
+    cft: 0.202,
+    rate: 93,
+    amount: 19.73,
+    subRows: [
+      {
+        materialName: "NC Thinner (Spl) 1",
+        cft: 0.202,
+        rate: 93,
+        amount: 19.73,
+      },
+      {
+        materialName: "NC Thinner (Spl) 2",
+        cft: 0.202,
+        rate: 93,
+        amount: 19.73,
+      },
+    ],
+  },
   { materialName: "Ultra Nitro Sealer 2", cft: 0.072, rate: 164, amount: 12.4 },
-  { materialName: "Ultra Nitro Matt 2", cft: 0.051, rate: 209, amount: 11.19 },
+  {
+    materialName: "Ultra Nitro Matt 2",
+    cft: 0.051,
+    rate: 209,
+    amount: 11.19,
+    subRows: [
+      {
+        materialName: "Ultra Nitro Matt 2 1",
+        cft: 0.051,
+        rate: 209,
+        amount: 11.19,
+      },
+      {
+        materialName: "Ultra Nitro Matt 2 2",
+        cft: 0.051,
+        rate: 209,
+        amount: 11.19,
+      },
+    ],
+  },
   { materialName: "Ultra Nitro Glossy 2", cft: 0.045, rate: 215, amount: 9.68 },
 ];
 
@@ -128,7 +166,6 @@ export default function HomePage() {
         showHeader={true} // First header visibility
         showSecondHeader={true} // Second header visibility
         secondHeaderTitle="Custom Title Example" // Title for the second header
-
         enableColumnSizing
       />
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -18,6 +18,7 @@ const Header = () => {
     { name: "Complex", href: "/" },
     { name: "Simple", href: "/normal" },
     { name: "Simple 2", href: "/normal-2" },
+    { name: "Sub Rows", href: "/sub-rows" },
   ];
 
   // Toggle between light and dark themes

--- a/src/components/sheet-table/index.tsx
+++ b/src/components/sheet-table/index.tsx
@@ -14,7 +14,7 @@ import React, { useState, useCallback } from "react";
 import {
   useReactTable,
   getCoreRowModel,
-  getExpandedRowModel,   // <-- For expansions
+  getExpandedRowModel, // <-- For expansions
   flexRender,
   TableOptions,
   Row as TanStackRow,
@@ -52,7 +52,11 @@ import { cn } from "@/lib/utils";
  * and sub-row expansions.
  */
 function SheetTable<
-  T extends Record<string, unknown> & { id?: string | number, headerKey?: string; subRows?: T[] }
+  T extends Record<string, unknown> & {
+    id?: string | number;
+    headerKey?: string;
+    subRows?: T[];
+  },
 >({
   columns,
   data,
@@ -116,8 +120,8 @@ function SheetTable<
       expanded,
       ...(enableColumnSizing
         ? {
-          columnSizing,
-        }
+            columnSizing,
+          }
         : {}),
     },
     onExpandedChange: setExpanded, // keep expansions in local state
@@ -125,9 +129,9 @@ function SheetTable<
     // If sizing is enabled, pass sizing states:
     ...(enableColumnSizing
       ? {
-        onColumnSizingChange: setColumnSizing,
-        columnResizeMode: tableOptions.columnResizeMode ?? "onChange",
-      }
+          onColumnSizingChange: setColumnSizing,
+          columnResizeMode: tableOptions.columnResizeMode ?? "onChange",
+        }
       : {}),
 
     // Spread any other user-provided table options
@@ -237,7 +241,7 @@ function SheetTable<
       const tanStackRow = findTableRow(rowData);
       if (!tanStackRow) return;
 
-      const rowId = tanStackRow.id;    // <--- Use rowId to
+      const rowId = tanStackRow.id; // <--- Use rowId to
       const colKey = getColumnKey(colDef);
 
       if (
@@ -248,7 +252,8 @@ function SheetTable<
       }
 
       const rawValue = e.currentTarget.textContent ?? "";
-      const originalValue = cellOriginalContent[groupKey]?.[rowId]?.[colKey] ?? "";
+      const originalValue =
+        cellOriginalContent[groupKey]?.[rowId]?.[colKey] ?? "";
 
       // If nothing changed, do nothing
       if (rawValue === originalValue) {
@@ -268,19 +273,19 @@ function SheetTable<
 
       if (errorMessage) {
         console.error(
-          `Group "${groupKey}", Row "${rowId}", Col "${colKey}" final error: ${errorMessage}`
+          `Group "${groupKey}", Row "${rowId}", Col "${colKey}" final error: ${errorMessage}`,
         );
       } else if (onEdit) {
         // Instead of rowIndex, we pass the row's unique ID from TanStack
         onEdit(rowId, colKey as keyof T, parsedValue as T[keyof T]);
       }
     },
-    [disabledColumns, disabledRows, findTableRow, cellOriginalContent, onEdit]
+    [disabledColumns, disabledRows, findTableRow, cellOriginalContent, onEdit],
   );
 
   /**
    * Group data by the `headerKey` field (top-level only).
-   * Sub-rows are handled by TanStack expansions. 
+   * Sub-rows are handled by TanStack expansions.
    */
   const groupedData = data.reduce<Record<string, T[]>>((acc, row) => {
     const group = row.headerKey || "ungrouped";
@@ -332,7 +337,10 @@ function SheetTable<
             }
 
             // For the first cell, we place the expand/collapse toggle if subRows exist.
-            let cellContent = flexRender(cell.column.columnDef.cell, cell.getContext());
+            let cellContent = flexRender(
+              cell.column.columnDef.cell,
+              cell.getContext(),
+            );
             if (cellIndex === 0 && hasSubRows) {
               cellContent = (
                 <div className="flex items-center gap-1">
@@ -350,7 +358,9 @@ function SheetTable<
             // Optional indentation for subRows
             // e.g. style={{ marginLeft: level * 20 }} or a left padding class
             // We'll do a small inline style here for demonstration:
-            const indentStyle: React.CSSProperties = { paddingLeft: level * 20 };
+            const indentStyle: React.CSSProperties = {
+              paddingLeft: level * 20,
+            };
 
             return (
               <TableCell
@@ -428,8 +438,8 @@ function SheetTable<
                 cellValue !== undefined
                   ? cellValue
                   : index === 0
-                    ? totalRowLabel || ""
-                    : "";
+                  ? totalRowLabel || ""
+                  : "";
 
               // Always apply the border to the first cell or any cell that has a displayValue
               const applyBorder = index === 0 || displayValue !== "";

--- a/src/components/sheet-table/index.tsx
+++ b/src/components/sheet-table/index.tsx
@@ -53,6 +53,7 @@ import { cn } from "@/lib/utils";
  */
 function SheetTable<
   T extends Record<string, unknown> & {
+    // Common properties for each row
     id?: string | number;
     headerKey?: string;
     subRows?: T[];

--- a/src/components/sheet-table/index.tsx
+++ b/src/components/sheet-table/index.tsx
@@ -21,6 +21,9 @@ import {
   ColumnSizingState,
 } from "@tanstack/react-table";
 
+// ** import icons
+import { ChevronDown, ChevronRight } from "lucide-react";
+
 // ** import ui components
 import {
   Table,
@@ -346,10 +349,10 @@ function SheetTable<
               cellContent = (
                 <div className="flex items-center gap-1">
                   <button
-                    className="text-sm"
                     onClick={() => row.toggleExpanded()}
                   >
-                    {isExpanded ? "▼" : "▶"}
+                    {/* Expand/collapse arrow */}
+                    {isExpanded ? <ChevronDown size={20} /> : <ChevronRight size={20} />}
                   </button>
                   {cellContent}
                 </div>

--- a/src/components/sheet-table/index.tsx
+++ b/src/components/sheet-table/index.tsx
@@ -7,17 +7,18 @@
  *  - A configurable footer (totals row + custom element)
  *  - TanStack Table column sizing (size, minSize, maxSize)
  *  - Forwarding other TanStack Table configuration via tableOptions
+ *  - Sub-rows (nested rows) with expand/collapse
  */
 
 import React, { useState, useCallback } from "react";
 import {
   useReactTable,
   getCoreRowModel,
+  getExpandedRowModel,   // <-- For expansions
   flexRender,
   TableOptions,
   Row as TanStackRow,
-  ColumnSizingState, // for type
-  // ColumnDef,          // for type if needed
+  ColumnSizingState,
 } from "@tanstack/react-table";
 
 // ** import ui components
@@ -47,10 +48,11 @@ import {
 import { cn } from "@/lib/utils";
 
 /**
- * The main SheetTable component, now with optional column sizing support.
+ * The main SheetTable component, now with optional column sizing support
+ * and sub-row expansions.
  */
 function SheetTable<
-  T extends Record<string, unknown> & { headerKey?: string },
+  T extends Record<string, unknown> & { id?: string | number, headerKey?: string; subRows?: T[] }
 >({
   columns,
   data,
@@ -78,6 +80,11 @@ function SheetTable<
   const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({});
 
   /**
+   * Expanded state for sub-rows. Keyed by row.id in TanStack Table.
+   */
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  /**
    * We still track errors/original content keyed by (groupKey, rowId) for editing.
    */
   const [cellErrors, setCellErrors] = useState<
@@ -93,22 +100,37 @@ function SheetTable<
   const mergedOptions: TableOptions<T> = {
     data,
     columns,
+    // Basic row model
+    getRowId: (row) => row.id, // Use the 'id' property as the row ID
     getCoreRowModel: getCoreRowModel(),
-    getSubRows: (row) => (row.subRows ? (row.subRows as T[]) : undefined),  // It returns returns T[] or undefined. T[] is the type of the subRows.
+    // Provide subRows if you have them:
+    getSubRows: (row) => (row.subRows ? row.subRows : undefined),
+    // Add expansions
+    getExpandedRowModel: getExpandedRowModel(),
+    enableExpanding: true,
+
+    // External expanded state
+    state: {
+      // If user also provided tableOptions.state, merge them
+      ...(tableOptions.state ?? {}),
+      expanded,
+      ...(enableColumnSizing
+        ? {
+          columnSizing,
+        }
+        : {}),
+    },
+    onExpandedChange: setExpanded, // keep expansions in local state
 
     // If sizing is enabled, pass sizing states:
     ...(enableColumnSizing
       ? {
-          state: {
-            // If user also provided tableOptions.state, merge them
-            ...tableOptions.state,
-            columnSizing,
-          },
-          onColumnSizingChange: setColumnSizing,
-          columnResizeMode: tableOptions.columnResizeMode ?? "onChange",
-        }
+        onColumnSizingChange: setColumnSizing,
+        columnResizeMode: tableOptions.columnResizeMode ?? "onChange",
+      }
       : {}),
-    // Spread any additional user-provided table options
+
+    // Spread any other user-provided table options
     ...tableOptions,
   } as TableOptions<T>;
 
@@ -122,7 +144,11 @@ function SheetTable<
    */
   const findTableRow = useCallback(
     (rowData: T): TanStackRow<T> | undefined => {
-      return table.getRowModel().rows.find((r) => r.original === rowData);
+      // NOTE: Because we have expansions, rowData might be in subRows.
+      // We can do a quick flatten search across all rows. We use table.getRowModel().flatRows
+      return table
+        .getRowModel()
+        .flatRows.find((r) => r.original.id === rowData.id);
     },
     [table],
   );
@@ -211,20 +237,18 @@ function SheetTable<
       const tanStackRow = findTableRow(rowData);
       if (!tanStackRow) return;
 
-      const rowId = tanStackRow.id;
-      const rowIndex = tanStackRow.index;
+      const rowId = tanStackRow.id;    // <--- Use rowId to
       const colKey = getColumnKey(colDef);
 
       if (
-        isRowDisabled(disabledRows, groupKey, rowIndex) ||
+        isRowDisabled(disabledRows, groupKey, tanStackRow.index) ||
         disabledColumns.includes(colKey)
       ) {
         return;
       }
 
       const rawValue = e.currentTarget.textContent ?? "";
-      const originalValue =
-        cellOriginalContent[groupKey]?.[rowId]?.[colKey] ?? "";
+      const originalValue = cellOriginalContent[groupKey]?.[rowId]?.[colKey] ?? "";
 
       // If nothing changed, do nothing
       if (rawValue === originalValue) {
@@ -244,18 +268,19 @@ function SheetTable<
 
       if (errorMessage) {
         console.error(
-          `Group "${groupKey}", Row "${rowId}", Col "${colKey}" final error: ${errorMessage}`,
+          `Group "${groupKey}", Row "${rowId}", Col "${colKey}" final error: ${errorMessage}`
         );
       } else if (onEdit) {
-        // We pass tanStackRow.index for the parent's usage
-        onEdit(tanStackRow.index, colKey as keyof T, parsedValue as T[keyof T]);
+        // Instead of rowIndex, we pass the row's unique ID from TanStack
+        onEdit(rowId, colKey as keyof T, parsedValue as T[keyof T]);
       }
     },
-    [disabledColumns, disabledRows, findTableRow, cellOriginalContent, onEdit],
+    [disabledColumns, disabledRows, findTableRow, cellOriginalContent, onEdit]
   );
 
   /**
-   * Group rows by the `headerKey` field.
+   * Group data by the `headerKey` field (top-level only).
+   * Sub-rows are handled by TanStack expansions. 
    */
   const groupedData = data.reduce<Record<string, T[]>>((acc, row) => {
     const group = row.headerKey || "ungrouped";
@@ -265,6 +290,111 @@ function SheetTable<
     acc[group].push(row);
     return acc;
   }, {});
+
+  /**
+   * A recursive function to render a row (and any sub-rows) in the table body.
+   * We respect existing logic for editing, disabling, error highlighting, etc.
+   *
+   * @param row - The TanStack row to render
+   * @param groupKey - The group name (for row disabling + error tracking)
+   * @param level - The nesting level (0 = top-level). We can indent sub-rows if desired.
+   */
+  const renderRow = (row: TanStackRow<T>, groupKey: string, level = 0) => {
+    const rowId = row.id;
+    const rowIndex = row.index;
+    const rowData = row.original;
+    const disabled = isRowDisabled(disabledRows, groupKey, rowIndex);
+
+    // We'll build a <TableRow> for the "parent" row, then if row is expanded,
+    // we recursively render subRows below it.
+    // Indent the first cell or add a toggle arrow if row has subRows.
+
+    const hasSubRows = row.getCanExpand(); // true if subRows exist
+    const isExpanded = row.getIsExpanded();
+
+    return (
+      <React.Fragment key={rowId}>
+        <TableRow className={disabled ? "bg-muted" : ""}>
+          {row.getVisibleCells().map((cell, cellIndex) => {
+            const colDef = cell.column.columnDef as ExtendedColumnDef<T>;
+            const colKey = getColumnKey(colDef);
+
+            const isDisabled = disabled || disabledColumns.includes(colKey);
+            const errorMsg = cellErrors[groupKey]?.[rowId]?.[colKey] || null;
+
+            // Column sizing style
+            const style: React.CSSProperties = {};
+            if (enableColumnSizing) {
+              const size = cell.column.getSize();
+              if (size) style.width = size + "px";
+              if (colDef.minSize) style.minWidth = colDef.minSize + "px";
+              if (colDef.maxSize) style.maxWidth = colDef.maxSize + "px";
+            }
+
+            // For the first cell, we place the expand/collapse toggle if subRows exist.
+            let cellContent = flexRender(cell.column.columnDef.cell, cell.getContext());
+            if (cellIndex === 0 && hasSubRows) {
+              cellContent = (
+                <div className="flex items-center gap-1">
+                  <button
+                    className="text-sm"
+                    onClick={() => row.toggleExpanded()}
+                  >
+                    {isExpanded ? "▼" : "▶"}
+                  </button>
+                  {cellContent}
+                </div>
+              );
+            }
+
+            // Optional indentation for subRows
+            // e.g. style={{ marginLeft: level * 20 }} or a left padding class
+            // We'll do a small inline style here for demonstration:
+            const indentStyle: React.CSSProperties = { paddingLeft: level * 20 };
+
+            return (
+              <TableCell
+                key={cell.id}
+                className={cn(
+                  "border",
+                  {
+                    "bg-muted": isDisabled,
+                    "bg-destructive/25": errorMsg,
+                  },
+                  typeof colDef.className === "function"
+                    ? colDef.className(rowData)
+                    : colDef.className,
+                )}
+                style={{ ...colDef.style, ...style, ...indentStyle }}
+                contentEditable={!isDisabled}
+                suppressContentEditableWarning
+                onFocus={(e) => handleCellFocus(e, groupKey, rowData, colDef)}
+                onKeyDown={(e) => {
+                  if (
+                    (e.ctrlKey || e.metaKey) &&
+                    // Let user do Ctrl+A, C, X, Z, V, etc.
+                    ["a", "c", "x", "z", "v"].includes(e.key.toLowerCase())
+                  ) {
+                    return; // do not block copy/paste
+                  }
+                  handleKeyDown(e, colDef);
+                }}
+                onPaste={(e) => handlePaste(e, colDef)}
+                onInput={(e) => handleCellInput(e, groupKey, rowData, colDef)}
+                onBlur={(e) => handleCellBlur(e, groupKey, rowData, colDef)}
+              >
+                {cellContent}
+              </TableCell>
+            );
+          })}
+        </TableRow>
+
+        {/* If expanded, render each subRow recursively */}
+        {isExpanded &&
+          row.subRows.map((subRow) => renderRow(subRow, groupKey, level + 1))}
+      </React.Fragment>
+    );
+  };
 
   /**
    * Renders optional footer content (rows) inside a <TableFooter>.
@@ -298,11 +428,10 @@ function SheetTable<
                 cellValue !== undefined
                   ? cellValue
                   : index === 0
-                  ? totalRowLabel || ""
-                  : "";
+                    ? totalRowLabel || ""
+                    : "";
 
-              // Always apply the border to the first cell (left edge)
-              // or any cell that has a displayValue.
+              // Always apply the border to the first cell or any cell that has a displayValue
               const applyBorder = index === 0 || displayValue !== "";
 
               return (
@@ -326,7 +455,9 @@ function SheetTable<
   return (
     <div className="p-4">
       <Table>
-        <TableCaption>Dynamic, editable data table with grouping.</TableCaption>
+        <TableCaption>
+          Dynamic, editable data table with grouping & nested sub-rows.
+        </TableCaption>
 
         {/* Primary header */}
         {showHeader && (
@@ -334,8 +465,6 @@ function SheetTable<
             <TableRow>
               {table.getHeaderGroups().map((headerGroup) =>
                 headerGroup.headers.map((header) => {
-                  // If column sizing is enabled, apply inline styles from TanStack (header.getSize()).
-                  // Also respect minSize/maxSize from the ExtendedColumnDef if set.
                   const style: React.CSSProperties = {};
                   if (enableColumnSizing) {
                     const col = header.column.columnDef;
@@ -373,8 +502,7 @@ function SheetTable<
         )}
 
         <TableBody>
-          {/* Main data rows */}
-          {Object.entries(groupedData).map(([groupKey, rows]) => (
+          {Object.entries(groupedData).map(([groupKey, topRows]) => (
             <React.Fragment key={groupKey}>
               {/* Group label row (if not ungrouped) */}
               {groupKey !== "ungrouped" && (
@@ -388,93 +516,15 @@ function SheetTable<
                 </TableRow>
               )}
 
-              {rows.map((rowData) => {
-                const tanStackRow = table
+              {/* For each top-level row in this group, find the actual row in table. 
+                  Then recursively render it with renderRow() */}
+              {topRows.map((rowData) => {
+                const row = table
                   .getRowModel()
-                  .rows.find((r) => r.original === rowData);
-                if (!tanStackRow) return null; // Data changed significantly?
+                  .flatRows.find((r) => r.original === rowData);
+                if (!row) return null;
 
-                const rowId = tanStackRow.id;
-                const rowIndex = tanStackRow.index;
-                const disabled = isRowDisabled(
-                  disabledRows,
-                  groupKey,
-                  rowIndex,
-                );
-
-                return (
-                  <TableRow key={rowId} className={disabled ? "bg-muted" : ""}>
-                    {tanStackRow.getVisibleCells().map((cell) => {
-                      const colDef = cell.column
-                        .columnDef as ExtendedColumnDef<T>;
-                      const colKey = getColumnKey(colDef);
-
-                      const isDisabled =
-                        disabled || disabledColumns.includes(colKey);
-
-                      const errorMsg =
-                        cellErrors[groupKey]?.[rowId]?.[colKey] || null;
-
-                      // If sizing is on, also apply styles in the cell
-                      const style: React.CSSProperties = {};
-                      if (enableColumnSizing) {
-                        const size = cell.column.getSize();
-                        if (size) style.width = size + "px";
-                        if (colDef.minSize)
-                          style.minWidth = colDef.minSize + "px";
-                        if (colDef.maxSize)
-                          style.maxWidth = colDef.maxSize + "px";
-                      }
-
-                      return (
-                        <TableCell
-                          key={cell.id}
-                          className={cn(
-                            "border", // Base class
-                            {
-                              "bg-muted": isDisabled, // Apply bg-muted if the cell is disabled
-                              "bg-destructive/25": errorMsg, // Apply bg-destructive/25 if there's an error
-                            },
-                            typeof colDef.className === "function"
-                              ? colDef.className(rowData) // Dynamic class name based on row data
-                              : colDef.className, // Static class name
-                          )}
-                          style={{ ...colDef.style, ...style }} // Combine column style with dynamic styles
-                          contentEditable={!isDisabled}
-                          suppressContentEditableWarning
-                          // Original content capture on focus
-                          onFocus={(e) =>
-                            handleCellFocus(e, groupKey, rowData, colDef)
-                          }
-                          // Let user do Ctrl+A, C, X, Z, V, etc.
-                          onKeyDown={(e) => {
-                            if (
-                              (e.ctrlKey || e.metaKey) &&
-                              ["a", "c", "x", "z", "v"].includes(
-                                e.key.toLowerCase(),
-                              )
-                            ) {
-                              return; // do not block
-                            }
-                            handleKeyDown(e, colDef);
-                          }}
-                          onPaste={(e) => handlePaste(e, colDef)}
-                          onInput={(e) =>
-                            handleCellInput(e, groupKey, rowData, colDef)
-                          }
-                          onBlur={(e) =>
-                            handleCellBlur(e, groupKey, rowData, colDef)
-                          }
-                        >
-                          {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext(),
-                          )}
-                        </TableCell>
-                      );
-                    })}
-                  </TableRow>
-                );
+                return renderRow(row, groupKey, 0);
               })}
             </React.Fragment>
           ))}

--- a/src/components/sheet-table/utils.ts
+++ b/src/components/sheet-table/utils.ts
@@ -89,7 +89,7 @@ export interface SheetTableProps<T extends object> extends FooterProps {
   /**
    * Callback for handling cell edits.
    */
-  onEdit?: <K extends keyof T>(rowIndex: number, columnId: K, value: T[K]) => void;
+  onEdit?: <K extends keyof T>(rowIndex: string, columnId: K, value: T[K]) => void;
 
   /**
    * Columns that are disabled for editing.

--- a/src/schemas/row-data-schema.ts
+++ b/src/schemas/row-data-schema.ts
@@ -21,4 +21,7 @@ export const rowDataZodSchema = z.object({
 /**
  * The inferred TypeScript type for row data based on the Zod schema.
  */
-export type RowData = z.infer<typeof rowDataZodSchema>;
+export type RowData = z.infer<typeof rowDataZodSchema> & {
+  // Add any additional properties here.
+  subRows?: RowData[]; // Add subRows for nested rows
+};

--- a/src/schemas/row-data-schema.ts
+++ b/src/schemas/row-data-schema.ts
@@ -11,6 +11,9 @@ import { z } from "zod";
  */
 export const rowDataZodSchema = z.object({
   headerKey: z.string().optional(), // NOTE: Key to define grouping (optional).
+
+  id: z.string(), // NOTE: Unique ID for each row. it's mandatory.
+
   materialName: z.string().min(1, "Material name cannot be empty."),
   cft: z.number().min(0, "CFT cannot be negative."),
   // .optional(), // BUG: Optional fields are not validated properly as number.


### PR DESCRIPTION
This pull request introduces several significant changes to enhance the handling of nested sub-rows and improve the overall functionality of the table components. The most important changes include adding unique identifiers to rows, updating the edit handling logic, and implementing support for nested sub-rows with expand/collapse functionality.

### Enhancements to Row Handling:

* Added `id` field to the `MyData` and `RowData` types to ensure each row has a unique identifier. [[1]](diffhunk://#diff-a61e81b5cd82f2c284a12895bc2ea40db2e15a3be6276261b39aeeff917d9e23R7) [[2]](diffhunk://#diff-4c148a2d55eca9047eb054b636854aee5ad03fb8f94b638c22614282617f5187L33-R37) [[3]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR36-R73)
* Updated initial data in `src/app/normal-2/page.tsx`, `src/app/normal/page.tsx`, and `src/app/page.tsx` to include unique `id` values for each row. [[1]](diffhunk://#diff-a61e81b5cd82f2c284a12895bc2ea40db2e15a3be6276261b39aeeff917d9e23L35-R37) [[2]](diffhunk://#diff-4c148a2d55eca9047eb054b636854aee5ad03fb8f94b638c22614282617f5187L33-R37) [[3]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR36-R73)

### Edit Handling Logic:

* Modified the `handleEdit` function to use `rowId` instead of `rowIndex` for identifying rows, ensuring updates are made based on unique row identifiers. [[1]](diffhunk://#diff-4c148a2d55eca9047eb054b636854aee5ad03fb8f94b638c22614282617f5187R84-R102) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR113-R131)
* Updated the `updateNestedRow` function to handle recursive updates for nested sub-rows based on `rowId`.

### Support for Nested Sub-Rows:

* Introduced `subRows` property to the `RowData` type and updated the initial data to include nested sub-rows.
* Enhanced `SheetTable` component to support sub-row expansions, including state management for expanded rows and recursive row updates. [[1]](diffhunk://#diff-243d090710f11e6e9703b6b9698675699db1c6d1bc4f383735e206dff43dbf4aR10-R26) [[2]](diffhunk://#diff-243d090710f11e6e9703b6b9698675699db1c6d1bc4f383735e206dff43dbf4aL50-R63) [[3]](diffhunk://#diff-243d090710f11e6e9703b6b9698675699db1c6d1bc4f383735e206dff43dbf4aR90-R94) [[4]](diffhunk://#diff-243d090710f11e6e9703b6b9698675699db1c6d1bc4f383735e206dff43dbf4aR111-R141) [[5]](diffhunk://#diff-243d090710f11e6e9703b6b9698675699db1c6d1bc4f383735e206dff43dbf4aL124-R161)

### Additional Changes:

* Added a new route for the sub-rows example in the `Header` component.
* Updated comments and documentation within the `SheetTable` component to reflect the new features and improvements. [[1]](diffhunk://#diff-243d090710f11e6e9703b6b9698675699db1c6d1bc4f383735e206dff43dbf4aL137-R172) [[2]](diffhunk://#diff-243d090710f11e6e9703b6b9698675699db1c6d1bc4f383735e206dff43dbf4aL152-R193) [[3]](diffhunk://#diff-243d090710f11e6e9703b6b9698675699db1c6d1bc4f383735e206dff43dbf4aL166-R204) [[4]](diffhunk://#diff-243d090710f11e6e9703b6b9698675699db1c6d1bc4f383735e206dff43dbf4aL202-R252) [[5]](diffhunk://#diff-243d090710f11e6e9703b6b9698675699db1c6d1bc4f383735e206dff43dbf4aL231-R292)