### PR TITLE
Fix the Col Span issue

### DIFF
--- a/src/app/sub-rows/page.tsx
+++ b/src/app/sub-rows/page.tsx
@@ -237,6 +237,13 @@ export default function HomePage() {
         showHeader={true}
         showSecondHeader={true}
         secondHeaderTitle="Custom Title Example"
+        totalRowTitle="Total"
+        totalRowValues={{
+          materialName: "Total",
+          cft: data.reduce((sum, row) => sum + (row.cft || 0), 0),
+          rate: data.reduce((sum, row) => sum + row.rate, 0),
+          amount: data.reduce((sum, row) => sum + row.amount, 0),
+        }}
         enableColumnSizing
       />
 

--- a/src/components/sheet-table/index.tsx
+++ b/src/components/sheet-table/index.tsx
@@ -49,6 +49,7 @@ import {
 
 // ** import lib
 import { cn } from "@/lib/utils";
+import { Button } from "../ui/button";
 
 /**
  * The main SheetTable component, now with optional column sizing support
@@ -330,24 +331,29 @@ function SheetTable<
       <React.Fragment key={rowId}>
         <TableRow className={disabled ? "bg-muted" : ""}>
           {/* Expand/collapse arrow cell */}
-          <TableCell
-            className={cn("border", {
-              "opacity-50 cursor-not-allowed": !hasSubRows, // Disable arrow for rows without sub-rows
-            })}
-          >
-            {hasSubRows && (
-              <button
-                onClick={() => row.toggleExpanded()}
-                disabled={!hasSubRows} // Disable button if no sub-rows
-              >
-                {isExpanded ? (
-                  <ChevronDown size={20} />
-                ) : (
-                  <ChevronRight size={20} />
-                )}
-              </button>
-            )}
-          </TableCell>
+          {hasExpandableRows && (
+            <TableCell
+              className={cn("border !w-[10px]", {
+                "opacity-50 cursor-not-allowed": !hasSubRows, // Disable arrow for rows without sub-rows
+              })}
+
+            >
+              {hasSubRows && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => row.toggleExpanded()}
+                  disabled={!hasSubRows} // Disable button if no sub-rows
+                >
+                  {isExpanded ? (
+                    <ChevronDown size={20} />
+                  ) : (
+                    <ChevronRight size={20} />
+                  )}
+                </Button>
+              )}
+            </TableCell>
+          )}
 
           {row.getVisibleCells().map((cell, cellIndex) => {
             const colDef = cell.column.columnDef as ExtendedColumnDef<T>;
@@ -486,7 +492,10 @@ function SheetTable<
           <TableHeader>
             <TableRow>
               {/* Empty header cell for expand/collapse column */}
-              <TableHead className="border" style={{ width: "40px" }} />
+              {hasExpandableRows && (
+                <TableHead className="border" />
+              )}
+
               {table.getHeaderGroups().map((headerGroup) =>
                 headerGroup.headers.map((header) => {
                   const style: React.CSSProperties = {};

--- a/src/components/sheet-table/index.tsx
+++ b/src/components/sheet-table/index.tsx
@@ -355,7 +355,7 @@ function SheetTable<
             </TableCell>
           )}
 
-          {row.getVisibleCells().map((cell, cellIndex) => {
+          {row.getVisibleCells().map((cell) => {
             const colDef = cell.column.columnDef as ExtendedColumnDef<T>;
             const colKey = getColumnKey(colDef);
 


### PR DESCRIPTION
This pull request introduces several enhancements to the `SheetTable` component, including support for expandable rows and the addition of a total row. The most important changes include adding the ability to check for expandable rows, updating the table structure to accommodate expandable rows, and ensuring the total row displays correctly.

Enhancements to `SheetTable` component:

* Added the ability to check if any rows have sub-rows and store this in the `hasExpandableRows` variable (`src/components/sheet-table/index.tsx`).
* Updated the table structure to include an expand/collapse arrow cell for rows with sub-rows and added a button to toggle row expansion (`src/components/sheet-table/index.tsx`).
* Modified the total row to account for the presence of expandable rows by adjusting the column span (`src/components/sheet-table/index.tsx`). [[1]](diffhunk://#diff-243d090710f11e6e9703b6b9698675699db1c6d1bc4f383735e206dff43dbf4aR448-R449) [[2]](diffhunk://#diff-243d090710f11e6e9703b6b9698675699db1c6d1bc4f383735e206dff43dbf4aR474-L462)
* Ensured the header and second header rows also account for the expandable rows by adjusting their column spans (`src/components/sheet-table/index.tsx`). [[1]](diffhunk://#diff-243d090710f11e6e9703b6b9698675699db1c6d1bc4f383735e206dff43dbf4aR494-R498) [[2]](diffhunk://#diff-243d090710f11e6e9703b6b9698675699db1c6d1bc4f383735e206dff43dbf4aL512-R534)

Addition of total row values:

* Added the `totalRowTitle` and `totalRowValues` properties to the `HomePage` component to display a total row with calculated values for `cft`, `rate`, and `amount` (`src/app/sub-rows/page.tsx`).

Other minor improvements:

* Imported the `Button` component to be used for the expand/collapse functionality (`src/components/sheet-table/index.tsx`).
* Simplified cell content rendering by removing redundant code and using the `flexRender` function directly (`src/components/sheet-table/index.tsx`).